### PR TITLE
Fix: provide coordinates to elevation service in lat, long order

### DIFF
--- a/src/transforms/Elevation.ts
+++ b/src/transforms/Elevation.ts
@@ -16,11 +16,12 @@ export default function addElevation(
     let elevations: number[];
     try {
       elevations = await loadElevations(
-        Array.from(coordinates).concat(elevationProfileCoordinates),
+        // Elevation service expects lat,lng order instead of lng,lat of GeoJSON
+        Array.from(coordinates).concat(elevationProfileCoordinates).map(([lng, lat]) => [lat, lng]),
         elevationServerURL
       );
     } catch (error) {
-      console.log("Failed to load elevations");
+      console.log("Failed to load elevations", error);
       return feature;
     }
 


### PR DESCRIPTION
@russellporter Thank you so much for the OpenSkiMap project! I was able to get the `openskidata-processor` running locally with very little trouble.

I ran into one issue with the elevation service. Running against a local instance of https://github.com/racemap/elevation-service, the elevation service returns: 

`{"error":"Invalid Payload. Expected a JSON array with valid latitude-longitude pairs: [[lat, lng], ...]"}`

Which causes `openskidata-processor` to log: 

`Failed to load elevations`

I believe this is because Elevation.ts is sending a request with coordinates in the `[longitude, latitude]` order of GeoJSON and elevation-service expects `[latitude, longitude]`. 

This change reverses the order of coordinates and now elevation loading works for me.

I can't come up with a confident explanation for how this apparently worked for you in the past and doesn't work for me. The options seem like:

* A change to elevation-service (but `racemap/elevation-service` hasn't changed for a year)
* A change to one of the dependencies in `openskidata-processor`
* We're using different implementations of elevation services

Let me know if you'd like me to change this PR in any way. Happy to help you out with this project. 