### PR TITLE
Replace ESM-only `uuid` usage with local `uuid()` wrapper to fix Jest parse errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,7 @@
         "sharp": "^0.33.5",
         "tmp": "^0.2.4",
         "topojson-client": "^3",
-        "topojson-server": "^3",
-        "uuid": "^14"
+        "topojson-server": "^3"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -55,7 +54,6 @@
         "@types/tmp": "^0.2.0",
         "@types/topojson-client": "^3",
         "@types/topojson-server": "^3",
-        "@types/uuid": "^10",
         "concurrently": "^9.1.0",
         "jest": "^29",
         "nock": "^14.0.0",
@@ -3772,13 +3770,6 @@
       "dependencies": {
         "@types/geojson": "*"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -8483,19 +8474,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "sharp": "^0.33.5",
     "tmp": "^0.2.4",
     "topojson-client": "^3",
-    "topojson-server": "^3",
-    "uuid": "^14"
+    "topojson-server": "^3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
@@ -62,7 +61,6 @@
     "@types/tmp": "^0.2.0",
     "@types/topojson-client": "^3",
     "@types/topojson-server": "^3",
-    "@types/uuid": "^10",
     "concurrently": "^9.1.0",
     "jest": "^29",
     "nock": "^14.0.0",

--- a/src/clustering/ClusterSkiAreas.integration.test.ts
+++ b/src/clustering/ClusterSkiAreas.integration.test.ts
@@ -24,8 +24,8 @@ import { toSkiAreaSummary } from "../transforms/toSkiAreaSummary";
 import clusterSkiAreas from "./ClusterSkiAreas";
 
 let mockUuidCount = 0;
-jest.mock("uuid", () => {
-  return { v4: () => "mock-UUID-" + mockUuidCount++ };
+jest.mock("../utils/uuid", () => {
+  return { uuid: () => "mock-UUID-" + mockUuidCount++ };
 });
 
 // Increase timeout to give time to set up PostgreSQL database

--- a/src/clustering/PostgreSQLClusteringIntegration.test.ts
+++ b/src/clustering/PostgreSQLClusteringIntegration.test.ts
@@ -19,9 +19,9 @@ import { Config, getPostgresTestConfig } from "../Config";
 jest.setTimeout(60 * 1000);
 
 let mockUuidCount = 0;
-jest.mock("uuid", () => {
+jest.mock("../utils/uuid", () => {
   return {
-    v4: () => "mock-UUID-" + mockUuidCount++,
+    uuid: () => "mock-UUID-" + mockUuidCount++,
   };
 });
 

--- a/src/clustering/SkiAreaClusteringService.ts
+++ b/src/clustering/SkiAreaClusteringService.ts
@@ -22,7 +22,7 @@ import {
 } from "openskidata-format";
 import { Writable } from "stream";
 import { pipeline } from "stream/promises";
-import { v4 as uuid } from "uuid";
+import { uuid } from "../utils/uuid";
 import {
   ElevationServerConfig,
   GeocodingServerConfig,

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,5 @@
+import { randomUUID } from "crypto";
+
+export function uuid(): string {
+  return randomUUID();
+}


### PR DESCRIPTION
### Motivation
- Jest was failing to parse the ESM-only `uuid@14` package (Unexpected token `export`) during tests, breaking many suites before they could run.
- The project needs deterministic, mockable UUID generation in tests and a CommonJS-compatible implementation for the current `ts-jest` setup.

### Description
- Added a tiny local UUID helper `src/utils/uuid.ts` that exports `uuid()` and uses Node's `crypto.randomUUID()` under the hood.
- Replaced the `uuid` import in `src/clustering/SkiAreaClusteringService.ts` to use the local `uuid` helper (`import { uuid } from "../utils/uuid";`).
- Updated tests that previously mocked the external `uuid` package to mock the local helper instead in `src/clustering/ClusterSkiAreas.integration.test.ts` and `src/clustering/PostgreSQLClusteringIntegration.test.ts` so existing deterministic `mock-UUID-*` behavior is preserved.
- Removed `uuid` and `@types/uuid` from `package.json`/`package-lock.json` to avoid pulling the ESM-only package into test runs.

### Testing
- Ran type checking with `npm run check-types` and it succeeded.
- Built the project with `npm run build` and it succeeded.
- Ran a focused Jest run for `src/transforms/MapboxGLFormatter.unit.test.ts` with `npm test -- --runInBand --runTestsByPath` and it passed, demonstrating tests no longer fail on the UUID ESM parse error.
- Ran integration and full test commands locally; full suite still fails in this environment due to missing PostgreSQL/Docker (database connectivity errors), but the previous Jest `Unexpected token 'export'` error coming from `uuid` no longer occurs and non-PostgreSQL suites proceed normally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd94f32dc88324ba052fdaf576e825)